### PR TITLE
Fix premature unicode_shutdown()

### DIFF
--- a/DriverManager/SQLConnect.c
+++ b/DriverManager/SQLConnect.c
@@ -2673,12 +2673,6 @@ void __disconnect_part_four( DMHDBC connection )
     }
 
     /*
-     * shutdown unicode
-     */
-
-    unicode_shutdown( connection );
-
-    /*
      * free some memory
      */
 
@@ -2907,12 +2901,6 @@ static void close_pooled_connection( CPOOL *ptr )
             ptr -> connection.dl_handle = NULL;
         }
 
-    	/*
-     	 * shutdown unicode
-     	 */
-
-    	unicode_shutdown( &ptr -> connection );
-
         /*
          * free some memory
          */
@@ -2963,12 +2951,6 @@ static void close_pooled_connection( CPOOL *ptr )
             }
             ptr -> connection.dl_handle = NULL;
         }
-
-    	/*
-     	 * shutdown unicode
-     	 */
-
-    	unicode_shutdown( &ptr -> connection );
 
         /*
          * free some memory

--- a/DriverManager/__handles.c
+++ b/DriverManager/__handles.c
@@ -743,6 +743,12 @@ void __release_dbc( DMHDBC connection )
 
     clear_error_head( &connection -> error );
 
+    /*
+     * shutdown unicode
+     */
+
+    unicode_shutdown( connection );
+
 #ifdef HAVE_LIBPTH
 #elif HAVE_LIBPTHREAD
     pthread_mutex_destroy( &connection -> mutex );

--- a/DriverManager/__handles.c
+++ b/DriverManager/__handles.c
@@ -621,6 +621,10 @@ DMHDBC __alloc_dbc( void )
         connection -> protection_level = TS_LEVEL3;
 #endif
 
+#ifdef HAVE_ICONV
+        connection -> iconv_cd_uc_to_ascii = (iconv_t)(-1);
+        connection -> iconv_cd_ascii_to_uc = (iconv_t)(-1);
+#endif
     }
 
     local_mutex_exit( &mutex_lists );

--- a/DriverManager/__info.c
+++ b/DriverManager/__info.c
@@ -492,6 +492,12 @@ int unicode_setup( DMHDBC connection )
     union { long l; char c[sizeof (long)]; } u;
     int be;
 
+    if ( connection -> iconv_cd_uc_to_ascii != (iconv_t)(-1) &&
+         connection -> iconv_cd_ascii_to_uc != (iconv_t)(-1))
+    {
+        return 1;
+    }
+
     /*
      * is this a bigendian machine ?
      */


### PR DESCRIPTION
If the driver connect attempt fails, and diagnostic records are generated in Unicode, an application would not retrieve them correctly since unicode_shutdown() would've freed the iconv()'ing descriptors already upon connection failure, causing the code to fall back to ASCII.

To fix this, I moved the shutdown to the very end of the connection handle's lifetime, and skip unicode_setup() if it has already occurred on the handle.