### PR TITLE
Postgres driver: Use struct in_addr

### DIFF
--- a/Drivers/Postgre7.1/socket.c
+++ b/Drivers/Postgre7.1/socket.c
@@ -100,7 +100,7 @@ SOCK_connect_to_ip(SocketClass *self, unsigned short port, char *hostname)
 {
 struct hostent *host;
 struct sockaddr_in sadr;
-unsigned long iaddr;
+struct in_addr iaddr;
 
 	if (self->socket != -1) {
 		self->errornumber = SOCKET_ALREADY_CONNECTED;
@@ -113,8 +113,8 @@ unsigned long iaddr;
 	/*	If it is a valid IP address, use it.
 		Otherwise use hostname lookup. 
 	*/
-	iaddr = inet_addr(hostname);
-	if (iaddr == INADDR_NONE) {
+	iaddr.s_addr = inet_addr(hostname);
+	if (iaddr.s_addr == INADDR_NONE) {
 		host = gethostbyname(hostname);
 		if (host == NULL) {
 			self->errornumber = SOCKET_HOST_NOT_FOUND;


### PR DESCRIPTION
Since we later memcopy:
```
memcpy(&(sadr.sin_addr), (struct in_addr *) &iaddr, sizeof(iaddr));
```

it is a good idea to to use the in_addr struct instead of the ulong to
make it work among all platforms and architectures.

Apply openSUSE patch: unixODBC-iaddr.patch