### PR TITLE
yyparse.c: Add semicolon

### DIFF
--- a/Drivers/nn/yyparse.c
+++ b/Drivers/nn/yyparse.c
@@ -2206,7 +2206,7 @@ static int	add_ins_value( yystmt_t* pstmt, node_t node, int idx)
 {
 	if( !idx )
 	{
-		MEM_FREE(pstmt->ins_values)
+		MEM_FREE(pstmt->ins_values);
 		pstmt->ins_values = (node_t*)MEM_ALLOC( FILTER_CHUNK_SIZE * sizeof(node_t));
 	}
 	else if( ! idx%FILTER_CHUNK_SIZE )

--- a/Drivers/nn/yyparse.y
+++ b/Drivers/nn/yyparse.y
@@ -1197,7 +1197,7 @@ static int	add_ins_value( yystmt_t* pstmt, node_t node, int idx)
 {
 	if( !idx )
 	{
-		MEM_FREE(pstmt->ins_values)
+		MEM_FREE(pstmt->ins_values);
 		pstmt->ins_values = (node_t*)MEM_ALLOC( FILTER_CHUNK_SIZE * sizeof(node_t));
 	}
 	else if( ! idx%FILTER_CHUNK_SIZE )


### PR DESCRIPTION
Not really needed when the macro is expanded. But it is used like this
everywhere else in the code. So let's apply this to be consistent.

Second part of openSUSE patch: unixODBC-2.3.1-bison.patch