### PR TITLE
Drivers/nn: Include ctype

### DIFF
--- a/Drivers/nn/yylex.c
+++ b/Drivers/nn/yylex.c
@@ -25,6 +25,7 @@
 # define	YYERRCODE	256
 
 #include	<stdio.h>
+#include	<ctype.h>
 
 static int	getcmpopidxbyname(char* name)
 {


### PR DESCRIPTION
Include ctype since isdigit() is used.

Part of openSUSE patch: unixODBC-2.3.1-declarations.patch