### PR TITLE
Drivers/nn: Include string.h

### DIFF
--- a/Drivers/nn/nnconfig.h
+++ b/Drivers/nn/nnconfig.h
@@ -21,6 +21,7 @@
 #  include	<stdlib.h>
 #  include	<errno.h>
 #  include	<sys/types.h>
+#  include	<string.h>
 
 #  define	MEM_ALLOC(size) (malloc((size_t)(size)))
 #  define	MEM_FREE(ptr)	{if(ptr) free(ptr);}


### PR DESCRIPTION
mem_set, and other string functions are used.

Adapted from the rest of openSUSE patch: unixODBC-2.3.1-declarations.patch
Which included the header in multiple files instead of the config.