### PR TITLE
Various fixes for SQLBrowseConnect/W, SQLGetConnectAttr/W,and SQLSetConnectAttr/W

### DIFF
--- a/DriverManager/SQLGetConnectAttr.c
+++ b/DriverManager/SQLGetConnectAttr.c
@@ -368,6 +368,37 @@ SQLRETURN SQLGetConnectAttr( SQLHDBC connection_handle,
                                 *string_length = sizeof(SQLLEN);
                             }
                         }
+                        else if(sa -> str_len >= SQL_IS_SMALLINT && sa -> str_len <= SQL_IS_POINTER)
+                        {
+                            SQLLEN length = 0;
+                            switch (sa -> str_len)
+                            {
+                            case SQL_IS_SMALLINT:
+                                *(SQLSMALLINT*)value = sa->int_attr;
+                                length = sizeof(SQLSMALLINT);
+                                break;
+                            case SQL_IS_USMALLINT:
+                                *(SQLUSMALLINT*)value = sa->int_attr;
+                                length = sizeof(SQLUSMALLINT);
+                                break;
+                            case SQL_IS_INTEGER:
+                                *(SQLINTEGER*)value = sa->int_attr;
+                                length = sizeof(SQLINTEGER);
+                                break;
+                            case SQL_IS_UINTEGER:
+                                *(SQLUINTEGER*)value = sa->int_attr;
+                                length = sizeof(SQLUINTEGER);
+                                break;
+                            case SQL_IS_POINTER:
+                                *(SQLPOINTER**)value = sa->int_attr;
+                                length = sizeof(SQLPOINTER);
+                                break;
+                            }
+                            if(string_length)
+                            {
+                                *string_length = length;
+                            }
+                        }
                         else
                         {
                             memcpy(value, &sa->int_attr, buffer_length);

--- a/DriverManager/SQLGetConnectAttrW.c
+++ b/DriverManager/SQLGetConnectAttrW.c
@@ -287,16 +287,16 @@ SQLRETURN SQLGetConnectAttrW( SQLHDBC connection_handle,
                         if (sa -> str_len == SQL_NTS || sa -> str_len > 0)
                         {
                             SQLLEN realLen = sa->str_attr ? strlen(sa->str_attr) : 0;
-                            if(value && sa->str_attr)
+                            if(value && sa->str_attr && buffer_length)
                             {
-                                strncpy(value, sa->str_attr, buffer_length - 1);
+                                ansi_to_unicode_copy( value, sa->str_attr, buffer_length/sizeof(SQLWCHAR), connection, NULL );
                                 ((SQLCHAR*)value)[buffer_length - 1] = 0;
                             }
                             if(string_length)
                             {
-                                *string_length = realLen;
+                                *string_length = realLen * sizeof(SQLWCHAR);
                             }
-                            if(realLen > buffer_length - 1)
+                            if(realLen * sizeof(SQLWCHAR) > buffer_length - 1)
                             {
                                 __post_internal_error( &connection -> error,
                                 ERROR_01004, NULL,
@@ -310,6 +310,37 @@ SQLRETURN SQLGetConnectAttrW( SQLHDBC connection_handle,
                             if(string_length)
                             {
                                 *string_length = sizeof(SQLLEN);
+                            }
+                        }
+                        else if(sa -> str_len >= SQL_IS_SMALLINT && sa -> str_len <= SQL_IS_POINTER)
+                        {
+                            SQLLEN length = 0;
+                            switch (sa -> str_len)
+                            {
+                            case SQL_IS_SMALLINT:
+                                *(SQLSMALLINT*)value = sa->int_attr;
+                                length = sizeof(SQLSMALLINT);
+                                break;
+                            case SQL_IS_USMALLINT:
+                                *(SQLUSMALLINT*)value = sa->int_attr;
+                                length = sizeof(SQLUSMALLINT);
+                                break;
+                            case SQL_IS_INTEGER:
+                                *(SQLINTEGER*)value = sa->int_attr;
+                                length = sizeof(SQLINTEGER);
+                                break;
+                            case SQL_IS_UINTEGER:
+                                *(SQLUINTEGER*)value = sa->int_attr;
+                                length = sizeof(SQLUINTEGER);
+                                break;
+                            case SQL_IS_POINTER:
+                                *(SQLPOINTER**)value = sa->int_attr;
+                                length = sizeof(SQLPOINTER);
+                                break;
+                            }
+                            if(string_length)
+                            {
+                                *string_length = length;
                             }
                         }
                         else

--- a/DriverManager/SQLSetConnectAttr.c
+++ b/DriverManager/SQLSetConnectAttr.c
@@ -248,7 +248,8 @@ SQLRETURN SQLSetConnectAttr( SQLHDBC connection_handle,
                         LOG_INFO, 
                         LOG_INFO, 
                         "Error: HY024" );
-        
+
+                function_entry( connection );
                 __post_internal_error( &connection -> error,
                     ERROR_HY024, NULL,
                     connection -> environment -> requested_version );
@@ -317,7 +318,8 @@ SQLRETURN SQLSetConnectAttr( SQLHDBC connection_handle,
                             LOG_INFO, 
                             LOG_INFO, 
                             "Error: HY024" );
-            
+
+                    function_entry( connection );
                     __post_internal_error( &connection -> error,
                         ERROR_HY024, NULL,
                         connection -> environment -> requested_version );
@@ -348,7 +350,8 @@ SQLRETURN SQLSetConnectAttr( SQLHDBC connection_handle,
                         LOG_INFO, 
                         LOG_INFO, 
                         "Error: HY024" );
-        
+
+                function_entry( connection );
                 __post_internal_error( &connection -> error,
                     ERROR_HY024, NULL,
                     connection -> environment -> requested_version );
@@ -496,8 +499,8 @@ SQLRETURN SQLSetConnectAttr( SQLHDBC connection_handle,
         /* ODBC 3.x statement attributes are not settable at the connection level */
         case SQL_ATTR_APP_PARAM_DESC:
         case SQL_ATTR_APP_ROW_DESC:
-      	case SQL_ATTR_CURSOR_SCROLLABLE:
-      	case SQL_ATTR_CURSOR_SENSITIVITY:
+        case SQL_ATTR_CURSOR_SCROLLABLE:
+        case SQL_ATTR_CURSOR_SENSITIVITY:
         case SQL_ATTR_ENABLE_AUTO_IPD:
         case SQL_ATTR_FETCH_BOOKMARK_PTR:
         case SQL_ATTR_IMP_PARAM_DESC:
@@ -667,9 +670,9 @@ SQLRETURN SQLSetConnectAttr( SQLHDBC connection_handle,
                 }
                 else
                 {
-                sa -> str_attr = strdup( value );
-                sa -> str_len = string_length;
-            }
+                    sa -> str_attr = strdup( value );
+                    sa -> str_len = string_length;
+                }
             }
             else
             {

--- a/DriverManager/SQLSetConnectAttrW.c
+++ b/DriverManager/SQLSetConnectAttrW.c
@@ -155,6 +155,7 @@ SQLRETURN SQLSetConnectAttrW( SQLHDBC connection_handle,
                         LOG_INFO, 
                         "Error: HY024" );
         
+                function_entry( connection );
                 __post_internal_error( &connection -> error,
                     ERROR_HY024, NULL,
                     connection -> environment -> requested_version );
@@ -223,7 +224,8 @@ SQLRETURN SQLSetConnectAttrW( SQLHDBC connection_handle,
                             LOG_INFO, 
                             LOG_INFO, 
                             "Error: HY024" );
-            
+
+                    function_entry( connection );
                     __post_internal_error( &connection -> error,
                         ERROR_HY024, NULL,
                         connection -> environment -> requested_version );
@@ -254,7 +256,8 @@ SQLRETURN SQLSetConnectAttrW( SQLHDBC connection_handle,
                         LOG_INFO, 
                         LOG_INFO, 
                         "Error: HY024" );
-        
+
+                function_entry( connection );
                 __post_internal_error( &connection -> error,
                     ERROR_HY024, NULL,
                     connection -> environment -> requested_version );
@@ -432,8 +435,8 @@ SQLRETURN SQLSetConnectAttrW( SQLHDBC connection_handle,
         /* ODBC 3.x statement attributes are not settable at the connection level */
         case SQL_ATTR_APP_PARAM_DESC:
         case SQL_ATTR_APP_ROW_DESC:
-      	case SQL_ATTR_CURSOR_SCROLLABLE:
-      	case SQL_ATTR_CURSOR_SENSITIVITY:
+        case SQL_ATTR_CURSOR_SCROLLABLE:
+        case SQL_ATTR_CURSOR_SENSITIVITY:
         case SQL_ATTR_ENABLE_AUTO_IPD:
         case SQL_ATTR_FETCH_BOOKMARK_PTR:
         case SQL_ATTR_IMP_PARAM_DESC:
@@ -603,13 +606,14 @@ SQLRETURN SQLSetConnectAttrW( SQLHDBC connection_handle,
                 }
                 else
                 {
-                sa -> str_attr = unicode_to_ansi_alloc( value, string_length, connection, NULL );
-                sa -> str_len = string_length;
-            }
+                    sa -> str_attr = unicode_to_ansi_alloc( value, string_length, connection, NULL );
+                    sa -> str_len = string_length;
+                }
             }
             else
             {
                 sa -> int_attr = ( SQLLEN ) value;
+                sa -> str_len = string_length;
             }
             sa -> next = connection -> save_attr;
             connection -> save_attr = sa;

--- a/DriverManager/__info.c
+++ b/DriverManager/__info.c
@@ -4183,7 +4183,7 @@ void clear_error_head( EHEAD *error_header )
  * get the error values from the handle
  */
 
-static void extract_diag_error( int htype,
+void extract_diag_error( int htype,
                             DRV_SQLHANDLE handle,
                             DMHDBC connection,
                             EHEAD *head,
@@ -4449,7 +4449,7 @@ static void extract_diag_error( int htype,
     while( SQL_SUCCEEDED( ret ));
 }
 
-static void extract_sql_error( DRV_SQLHANDLE henv,
+void extract_sql_error( DRV_SQLHANDLE henv,
                             DRV_SQLHANDLE hdbc,
                             DRV_SQLHANDLE hstmt,
                             DMHDBC connection,
@@ -4560,7 +4560,7 @@ static void extract_sql_error( DRV_SQLHANDLE henv,
     while( SQL_SUCCEEDED( ret ));
 }
 
-static void extract_diag_error_w( int htype,
+void extract_diag_error_w( int htype,
                             DRV_SQLHANDLE handle,
                             DMHDBC connection,
                             EHEAD *head,
@@ -4804,7 +4804,7 @@ static void extract_diag_error_w( int htype,
     while( SQL_SUCCEEDED( ret ));
 }
 
-static void extract_sql_error_w( DRV_SQLHANDLE henv,
+void extract_sql_error_w( DRV_SQLHANDLE henv,
                             DRV_SQLHANDLE hdbc,
                             DRV_SQLHANDLE hstmt,
                             DMHDBC connection,
@@ -5419,7 +5419,7 @@ void __post_internal_error_api( EHEAD *error_handle,
 
       case ERROR_08002:
         strcpy( sqlstate, "08002" );
-        message = "Connection name in use";
+        message = "Connection in use";
         break;
 
       case ERROR_08003:
@@ -5691,7 +5691,7 @@ void __post_internal_error_api( EHEAD *error_handle,
 
       case ERROR_IM002:
         strcpy( sqlstate, "IM002" );
-        message = "Data source name not found, and no default driver specified";
+        message = "Data source name not found and no default driver specified";
         subclass = SUBCLASS_ODBC;
         class = SUBCLASS_ODBC;
         break;


### PR DESCRIPTION
- SQLBrowseConnect: fix buffer overflow, Unicode conversion, and error extraction
- SQLBrowseConnectW: fix buffer overflow, missing HY090 check, missing IM001 check, and error extraction - also made the code more consistent with SQLBrowseConnect
- SQLGetConnectAttr/W - allow getting set fixed-length custom per-connect attributes, fix Unicode conversion(W)
- SQLSetConnectAttrW - fix omitted field assignment in structure, and clear errors from previous calls before posting errors on trace attributes
- Made error messages more consistent with Windows' DM

I see 2.3.7 is coming, hope these fixes can make it.