### PR TITLE
Fix buffer overflows in SQLConnect/W and refine behaviour of SQLGet/WritePrivateProfileString

### DIFF
--- a/DriverManager/SQLConnect.c
+++ b/DriverManager/SQLConnect.c
@@ -4186,7 +4186,7 @@ SQLRETURN SQLConnect( SQLHDBC connection_handle,
                             sqlstate,
                             &native_error,
                             message_text,
-                            sizeof( message_text ),
+                            sizeof( message_text )/sizeof(SQLWCHAR),
                             &ind );
 
 
@@ -4228,7 +4228,7 @@ SQLRETURN SQLConnect( SQLHDBC connection_handle,
                             sqlstate,
                             &native_error,
                             message_text,
-                            sizeof( message_text ),
+                            sizeof( message_text )/sizeof(SQLWCHAR),
                             &ind );
 
                     if ( SQL_SUCCEEDED( ret ))

--- a/DriverManager/SQLConnectW.c
+++ b/DriverManager/SQLConnectW.c
@@ -463,7 +463,7 @@ SQLRETURN SQLConnectW( SQLHDBC connection_handle,
                             sqlstate,
                             &native_error,
                             message_text,
-                            sizeof( message_text ),
+                            sizeof( message_text )/sizeof(SQLWCHAR),
                             &ind );
 
 
@@ -501,7 +501,7 @@ SQLRETURN SQLConnectW( SQLHDBC connection_handle,
                             sqlstate,
                             &native_error,
                             message_text,
-                            sizeof( message_text ),
+                            sizeof( message_text )/sizeof(SQLWCHAR),
                             &ind );
 
 

--- a/odbcinst/SQLGetPrivateProfileString.c
+++ b/odbcinst/SQLGetPrivateProfileString.c
@@ -429,6 +429,10 @@ int SQLGetPrivateProfileString( LPCSTR  pszSection,
 
             return ret;
         }
+        else if ( !*pszFileName )
+        {
+            return 0; /* Asking for empty filename returns nothing, not even default */
+        }
     }
 
     /*****************************************************

--- a/odbcinst/SQLWritePrivateProfileString.c
+++ b/odbcinst/SQLWritePrivateProfileString.c
@@ -54,8 +54,8 @@ BOOL SQLWritePrivateProfileString(
 		strcpy( szFileName, pszFileName );
 	}
 	else
-	{	
-		if ( _odbcinst_ConfigModeINI( szFileName ) == FALSE )
+	{
+		if ( !*pszFileName || _odbcinst_ConfigModeINI( szFileName ) == FALSE )
 		{
         	inst_logPushMsg( __FILE__, __FILE__, __LINE__, LOG_CRITICAL, ODBC_ERROR_REQUEST_FAILED, "" );
 			return FALSE;


### PR DESCRIPTION
- fix buffer overflows in SQLConnect/W upon retrieving errors (number of bytes/characters confusion)
- make SQLGet/WritePrivateProfileString refuse to read/write with empty filename argument --- this more closely aligns behaviour with Windows' DM