### PR TITLE
Remove redundant call to mkdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,6 @@ EXTRA_DIST = \
 	Makefile.svn
 
 install-data-am: install-pkgconfigDATA
-	-mkdir -p $(DESTDIR)${sysconfdir}
 	-mkdir -p $(DESTDIR)${sysconfdir}/ODBCDataSources
 	-touch $(DESTDIR)${sysconfdir}/odbcinst.ini
 	-touch $(DESTDIR)${sysconfdir}/odbc.ini


### PR DESCRIPTION
It should be enough like this since mkdir will create all the
directories because we use the `-p` flag.

I guess the problem just happened because we touched a file already in a
directory that might not exist. By having:
`-touch $(DESTDIR)${sysconfdir}/odbcinst.ini`
before the mkdir call.