### PR TITLE
Add cross references and some basic tips to the man pages

### DIFF
--- a/exe/isql.h
+++ b/exe/isql.h
@@ -19,11 +19,13 @@
 char *szSyntax =
 "\n" \
 "**********************************************\n" \
-"* unixODBC - isql                            *\n" \
+"* unixODBC - isql and iusql                  *\n" \
 "**********************************************\n" \
 "* Syntax                                     *\n" \
 "*                                            *\n" \
 "*      isql DSN [UID [PWD]] [options]        *\n" \
+"*                                            *\n" \
+"*      iusql DSN [UID [PWD]] [options]       *\n" \
 "*                                            *\n" \
 "* Options                                    *\n" \
 "*                                            *\n" \
@@ -53,12 +55,16 @@ char *szSyntax =
 "*                                            *\n" \
 "* Examples                                   *\n" \
 "*                                            *\n" \
-"*      isql WebDB MyID MyPWD -w < My.sql     *\n" \
+"*      iusql -v WebDB MyID MyPWD -w < My.sql *\n" \
 "*                                            *\n" \
 "*      Each line in My.sql must contain      *\n" \
 "*      exactly 1 SQL command except for the  *\n" \
 "*      last line which must be blank (unless *\n" \
 "*      -n option specified).                 *\n" \
+"*                                            *\n" \
+"* Datasources, drivers, etc:                 *\n" \
+"*                                            *\n" \
+"*      See \"man 1 isql\"                    *\n" \
 "*                                            *\n" \
 "* Please visit;                              *\n" \
 "*                                            *\n" \
@@ -72,11 +78,13 @@ char *szSyntax =
 char *szSyntax =
 "\n" \
 "**********************************************\n" \
-"* unixODBC - isql                            *\n" \
+"* unixODBC - isql and iusql                  *\n" \
 "**********************************************\n" \
 "* Syntax                                     *\n" \
 "*                                            *\n" \
 "*      isql DSN [UID [PWD]] [options]        *\n" \
+"*                                            *\n" \
+"*      iusql DSN [UID [PWD]] [options]       *\n" \
 "*                                            *\n" \
 "* Options                                    *\n" \
 "*                                            *\n" \
@@ -91,7 +99,6 @@ char *szSyntax =
 "* -v         verbose.                        *\n" \
 "* -q         wrap char fields in dquotes     *\n" \
 "* --version  version                         *\n" \
-"* --version  version                         *\n" \
 "*                                            *\n" \
 "* Commands                                   *\n" \
 "*                                            *\n" \
@@ -101,11 +108,15 @@ char *szSyntax =
 "*                                            *\n" \
 "* Examples                                   *\n" \
 "*                                            *\n" \
-"*      isql WebDB MyID MyPWD -w < My.sql     *\n" \
+"*      iusql -v WebDB MyID MyPWD -w < My.sql *\n" \
 "*                                            *\n" \
 "*      Each line in My.sql must contain      *\n" \
 "*      exactly 1 SQL command except for the  *\n" \
 "*      last line which must be blank.        *\n" \
+"*                                            *\n" \
+"* Datasources, drivers, etc:                 *\n" \
+"*                                            *\n" \
+"*      See \"man 1 isql\"                    *\n" \
 "*                                            *\n" \
 "* Please visit;                              *\n" \
 "*                                            *\n" \

--- a/man/isql.1
+++ b/man/isql.1
@@ -1,4 +1,4 @@
-\" vim:language en_US.UTF-8:
+\" vim:fileencoding=utf-8:
 .TH isql 1 "Tue 25 Jun 2013" "version 2.3.6" "UnixODBC manual pages"
 
 .SH NAME
@@ -14,7 +14,8 @@ or interactively. It has some interesting options such as an option to generate
 output wrapped in an HTML table.
 
 .B iusql
-is the same tool with built-in Unicode support.
+is the same tool with built-in Unicode support. Some datasources only work with
+\fBiusql\fR.
 
 .SH ARGUMENTS
 
@@ -23,11 +24,19 @@ The Data Source Name, which should be used to make connection to the database.
 The data source is looked for in the /etc/odbc.ini and $HOME/.odbc.ini files in
 that order, with the latter overwriting the former.
 
+A bare name is looked up in the above files. If the DSN name begins with a
+semicolon then it's treated as a connection string instead. The connection
+string may contain a DSN name and/or other semicolon-separated parameters.
+
 .IP \fBUSER\fR
 Specifies the database user/role under which the connection should be made.
 
+Overrides any \fBUID\fR specified in the DSN.
+
 .IP \fBPASSWORD\fR
 Password for the specified \fBUSER\fR.
+
+Overrides any \fBPassword\fR specified in the DSN.
 
 .SH OPTIONS
 
@@ -98,14 +107,77 @@ List all help options.
 .RE
 
 .SH EXAMPLES
+
+.IP "A bare DSN name:"
+
 .nf
-$ isql WebDB MyID MyPWD -w -b < My.sql
+$ iusql WebDB MyID MyPWD -w -b < My.sql
 .fi
 
 Connects to the WebDB as user MyID with password MyPWD, then execute the
 commands in the My.sql file and returns the results wrapped in HTML table.
 Each line in My.sql must contain exactly 1 SQL command, except for the last
 line, which must be blank (unless the \fB-n\fR option is specified).
+
+.IP "A DSN name in a connection string:"
+
+Note the leading semicolon on the connection string:
+
+.nf
+$ iusql ";DSN=WebDB" MyID MyPWD -w -b < My.sql
+.fi
+
+Options in the DSN may be overridden in the connection string:
+
+.nf
+$ iusql ";DSN=WebDB;Driver=PostgreSQL ODBC;UID=MyID;PASSWORD=secret;Debug=1;CommLog=1" -v
+.fi
+
+.IP "A string DSN:"
+
+A string DSN may be provided in its entirety, with no file DSN reference at
+all:
+
+.nf
+$ iusql ";Driver=PostgreSQL Unicode;UID=MyID;PASSWORD=secret" -v
+.fi
+
+.SH TROUBLESHOOTING
+
+.IP "Cryptic error messages"
+
+Re-run \fBiusql\fR or \fBisql\fR with the \fB-v\fR flag to get more detail
+from errors, and/or enable \fBTrace\fR mode in \fBodbcinst.ini\fR.
+
+.IP "Missing driver definition"
+
+Check that the driver name specified by the \fBDriver\fR entry in  the
+\fBodbc.ini\fR data-source definition is present in \fBodbcinst.ini\fR and
+exactly matches the odbcinst \fI[section name]\fR.
+
+.IP "Unloadable or incompatible driver"
+
+If the driver is properly specified for the datasource it's possible that
+the driver may not be loadable. Check for mixups between Unicode and ANSI
+drivers. Verify the driver paths in the \fBodbcinst.ini\fR section name.
+
+.IP "Unicode datasources with ANSI clients"
+
+Some datasources are Unicode-only and only work with \fBiusql\fR. If \fBisql\fR
+reports
+.nf
+  [IM002][unixODBC][Driver Manager]Data source name not found and no default driver specified
+  [ISQL]ERROR: Could not SQLConnect
+.fi
+but the datasource is listed by
+.nf
+  odbcinst -q -d
+.fi
+and the driver it uses is listed by
+.nf
+  odbcinst -q -d
+.fi
+then try \fBiusql\fR.
 
 .SH FILES
 
@@ -124,8 +196,11 @@ for details.
 .RE
 
 .SH SEE ALSO
+.BR unixODBC (7),
 .BR odbcinst (1),
 .BR odbc.ini (5)
+
+.R "The \fIunixODBC\fB Administrator Manual (HTML)"
 
 .SH AUTHORS
 

--- a/man/odbc.ini.5
+++ b/man/odbc.ini.5
@@ -8,12 +8,73 @@
 is text configuration file for the system wide ODBC data sources (i. e. database
 connections).
 .B $HOME/.odbc.ini
-contains the configuration for user-specific data sources.
+contains the configuration for user-specific data sources. Both paths may be overridden
+by \fIunixODBC\fR build options, see \fBodbcinst -j\fR for the definitive paths
+on your system.
+
+.SH NOTES
+
+.SS "Templates"
+
+Where possible, install ODBC DSNs using the \fBodbcinst\fR utility from a
+template .ini file. Many drivers supply templates.
+
+.SS "FILE FORMAT"
+
+\fBodbc.ini\fR follows the pesudo-standard \fIini file\fB syntax convention of
+one or more \fB[section headings]\fR, each followed by zero or more \fBkey =
+value\fR attributes.
+
+.IP "\fB[ODBC Data Sources]\fR section" 4
+
+The required section \fB[ODBC Data Sources]\fR lists each data source name
+(\fIDSN\fR) as a key. The associated values serve as comments. Each entry
+must be matched by an ini file \fB[section]\fR describing the data source.
+
+.IP "\fB[\fIdsn\fR]\fR sections" 4
+
+Each data source is identified by a \fB[section header]\fR, which is the DSN
+name used by applications. Each DSN definition section may contain values for
+the keys:
+
+.RS 4
+.IP "\(bu Driver (\fBREQUIRED\fR)" 8
+Name of the ODBC driver to use for this DSN. The name must exactly match
+the \fB[section name]\fR of the driver definition in \fBodbcinst.ini\fR
+as listed by \fBodbcinst -q -d\fR.
+
+.IP "\(bu Description" 8
+
+Human-readable data source description.
+
+.IP "\(bu Database" 8
+
+Database name or identifier. Meaning is driver-specific. May specify a file
+path, unix socket path, identifier relative to a server name, etc.
+
+.IP "\(bu Servername" 8
+
+Server name. Meaning is driver specific, but generally specifies a DNS name, IP
+network address, or driver-specific discovery identifier.
+
+.RE
+For a full list of supported parameters see the HTML-format "Administrator
+Manual" shipped with \fIunixODBC\fR, the documentation for your driver, and any
+datasource templates supplied by your driver.
+
+.SH EXAMPLES
+
+An example \fBodbc.init\fR is shown in the "Administrator Manual" shipped
+with \fIunixODBC\fR.
 
 .SH "SEE ALSO"
+.BR unixODBC (7),
 .BR odbcinst (1),
 .BR isql (1),
+.BR iusql (1),
 .BR odbcinst.ini (5)
+
+.R "The \fIunixODBC\fB Administrator Manual (HTML)"
 
 .SH AUTHORS
 The authors of unixODBC are Peter Harvey <\fIpharvey@codebydesign.com\fR> and

--- a/man/odbc_config.1
+++ b/man/odbc_config.1
@@ -94,8 +94,11 @@ Compiler flag for defining
 .IR SIZEOF_SQLULEN .
 
 .SH SEE ALSO
+.BR unixODBC (7),
 .BR odbcinst.ini (5),
 .BR odbc.ini (5)
+
+.R "The \fIunixODBC\fB Administrator Manual (HTML)"
 
 .SH AUTHORS
 The authors of unixODBC are

--- a/man/odbcinst.1
+++ b/man/odbcinst.1
@@ -77,6 +77,34 @@ The specified data source is user-specific. Has any effect only with the -s
 .SH "RETURN VALUES"
 This command returns zero on success and non-zero value on failure.
 
+.SH EXAMPLES
+
+.IP "List drivers defined in odbcinst.ini:"
+
+.nf
+$ odbcinst -q -d
+.fi
+
+Lists both Unicode and ANSI drivers.
+
+.IP "List file DSNs from /etc/odbc.ini and $HOME/.odbc.ini:"
+
+.nf
+$ odbcinst -q -s
+.fi
+
+Lists both Unicode and ANSI datasources.
+
+To show only user DSNs append \fB-h\fR. For only system DSNs append \fB-l\fR. The error
+\fI"SQLGetPrivateProfileString failed with ."\fR will be emitted if there are
+no DSNs defined and/or the \fB[ODBC Data Sources]\fR section is missing.
+
+.IP "Print file paths and version information:"
+
+.nf
+$ odbcinst -j
+.fi
+
 .SH FILES
 
 .I /etc/odbinst.ini
@@ -101,8 +129,11 @@ for more details.
 .RE
 
 .SH "SEE ALSO"
+.BR unixODBC (7),
 .BR odbcinst.ini (5),
 .BR odbc.ini (5)
+
+.R "The \fIunixODBC\fB Administrator Manual (HTML)"
 
 .SH AUTHORS
 The authors of unixODBC are Peter Harvey <\fIpharvey@codebydesign.com\fR> and

--- a/man/odbcinst.ini.5
+++ b/man/odbcinst.ini.5
@@ -28,7 +28,7 @@ The general .ini file format is:
 .RE
 
 Each ODBC driver has its own section and can be referred to by the name of its
-section. Recognized configuration keys are:
+section. Configuration keys recognised in driver sections by unixODBC itself are:
 
 .IP \fBDescription
 A text string briefly describing the driver.
@@ -40,8 +40,27 @@ A filesystem path to the actual driver library.
 A filesystem path to the driver setup library.
 
 .IP \fBFileUsage
-.BR odbcinst (1)
-entry, if you edit the configuration file by hand, you have to supply it yourself.
+
+The section named \fB[ODBC]\fR configures global options. Keys recognised in
+the \fB[ODBC]\fR section include:
+
+.IP \fBTrace\fB
+
+Enable ODBC driver trace output, which is written to the path specified by \fBTraceFile\fR.
+
+Note that some drivers have their own separate trace control options. Unlike
+the \fBTrace\fR option these are usually specified at the DSN level.
+
+Values recognised as enabled are any case variation of "1", "y", "yes" or "on".
+
+.IP \fBTraceFile\fB
+
+Path or path-pattern to write the ODBC trace file to. Has no effect unless
+\fBTrace\fR is enabled. Default \fB/tmp/sql.log\fR.
+
+\fIWARNING\fR: setting \fBTraceFile\fB to a path writeable by multiple users
+may not work correctly as only the first user will be able to create and open
+the file.
 
 .SS TEMPLATE FILES
 The recommended way to manage the drivers is using the
@@ -61,6 +80,9 @@ Setup       = /usr/lib/libodbcpsqlS.so
 FileUsage   = 1
 .fi
 .RE
+
+Note that driver paths may vary, and some drivers require \fBDriver64\fR and
+\fBSetup64\fR entries too.
 
 By specifying the driver like that, you can then reference it in the
 .BR odbc.ini (5)
@@ -91,8 +113,11 @@ and call the
 .RE
 
 .SH "SEE ALSO"
+.BR unixODBC (7),
 .BR odbcinst (1),
 .BR odbc.ini (5)
+
+.R "The \fIunixODBC\fB Administrator Manual (HTML)"
 
 .SH AUTHORS
 The authors of unixODBC are Peter Harvey <\fIpharvey@codebydesign.com\fR> and

--- a/man/unixODBC.7
+++ b/man/unixODBC.7
@@ -11,6 +11,9 @@ Servers and any Data Source with an ODBC Driver.
 The unixODBC Project goals are to develop and promote unixODBC to be the
 definitive standard for ODBC on non MS Windows platforms.
 
+The HTML-format "Administrator Manual" shipped with \fIunixODBC\fR provides
+additional details on configuration and usage to supplement these man pages.
+
 .SH ENVIRONMENT VARIABLES
 
 .IP \fBODBCSYSINI
@@ -35,10 +38,13 @@ Overloads the path to user configuration file. By default it is set
 to "~/.odbc.ini".
 
 .SH SEE ALSO
+.BR unixODBC (7),
 .BR isql (1),
 .BR odbcinst (1),
 .BR odbc.ini (5),
 .BR odbcinst.ini (5)
+
+.R "The \fIunixODBC\fB Administrator Manual (HTML)"
 
 .SH AUTHORS
 


### PR DESCRIPTION
Enhance the unixODBC manual pages

Small enhancements to:

* "SEE ALSO" unixodbc(7) from the other pages
* cross reference the HTML manual
* supply a minimal odbc.ini syntax description
* supply a minimal odbcinst.ini explanation
* add a few simple odbcinst examples for listing drivers and dsns
* add simple isql examples for string dsn connections
* add a few troubleshooting hints for isql