### PR TITLE
Fix calling unicode_to_ansi_copy() in SQLDriverConnectW

### DIFF
--- a/DriverManager/SQLDriverConnectW.c
+++ b/DriverManager/SQLDriverConnectW.c
@@ -709,20 +709,21 @@ SQLRETURN SQLDriverConnectW(
     else
     {
         char *in_str, *out_str;
-        int len;
+        int in_len, len;
 
         if ( conn_str_in )
         {
             if ( len_conn_str_in == SQL_NTS )
             {
-                len = wide_strlen( conn_str_in ) + sizeof( SQLWCHAR );
+                len = wide_strlen( conn_str_in );
             }
             else
             {
-                len = len_conn_str_in + sizeof( SQLWCHAR );
+                len = len_conn_str_in;
             }
-            in_str = malloc( len );
-            unicode_to_ansi_copy( in_str, len, conn_str_in, len, connection, NULL );
+            in_len = len + 1;
+            in_str = malloc( in_len );
+            unicode_to_ansi_copy( in_str, in_len, conn_str_in, len, connection, NULL );
         }
         else
         {


### PR DESCRIPTION
There are more problems related to buffer lengths:

1. unicode_to_ansi_copy() in its first argument (in_str) expects single
   byte output buffer (SQLCHAR), in its second argument length of output
   buffer and therefore passing length of this buffer based on
   sizeof(SQLWCHAR) is wrong and does not make any sense.

2. unicode_to_ansi_copy() in its third argument (conn_str_in) expects wide
   character input buffer (SQLWCHAR), in its fourth argument number of
   characters in input buffer and therefore increasing this length would
   just lead to memory corruption (reading memory after end of allocated
   array).

3. wide_strlen() returns number of wide characters in null-terminated wide
   character buffer. Therefore doing sum of sizeof(SQLWCHAR) and number of
   characters does not make any sense. sizeof(SQLWCHAR) return bytes, not
   number of characters.

This patch fixes these problems with following changes:

1. Calculate length of output buffer (in_str) correctly, use number of
   characters in input buffer (conn_str_in) increased by 1 for null-term
   byte.

2. Do not touch length of input buffer (conn_str_in). When length if
   specified as SQL_NTS, calculate it via wide_strlen().

3. Remove nonsense sizeof(SQLWCHAR).