### PR TITLE
Update pkg-config templates

### DIFF
--- a/DriverManager/odbc.pc.in
+++ b/DriverManager/odbc.pc.in
@@ -8,10 +8,12 @@ longodbcversion=3.52
 odbcini=@SYSTEM_FILE_PATH@/odbc.ini
 odbcinstini=@SYSTEM_FILE_PATH@/odbcinst.ini
 ulen=@ODBC_ULEN@
+build_cflags=@ODBC_CFLAGS@
 
-Name: unixODBC
-Description: unixODBC is an Open Source ODBC sub-system.
+Name: odbc (@PACKAGE_NAME@)
+Description: unixODBC Driver Manager library
 URL: http://unixodbc.org
 Version: @PACKAGE_VERSION@
-Cflags: @ODBC_CFLAGS@ -I${includedir}
+Cflags: -I${includedir}
 Libs: -L${libdir} -lodbc
+Libs.private: @LIBLTDL@ @LIBS@

--- a/cur/odbccr.pc.in
+++ b/cur/odbccr.pc.in
@@ -3,9 +3,10 @@ exec_prefix=@exec_prefix@
 includedir=@includedir@
 libdir=@libdir@
 
-Name: unixODBC
-Description: unixODBC is an Open Source ODBC sub-system.
+Name: odbccr (@PACKAGE_NAME@)
+Description: unixODBC Cursor Library
 URL: http://unixodbc.org
 Version: @PACKAGE_VERSION@
+Requires: odbc
 Cflags: -I${includedir}
 Libs: -L${libdir} -lodbccr

--- a/odbcinst/odbcinst.pc.in
+++ b/odbcinst/odbcinst.pc.in
@@ -3,9 +3,10 @@ exec_prefix=@exec_prefix@
 includedir=@includedir@
 libdir=@libdir@
 
-Name: unixODBC
-Description: unixODBC is an Open Source ODBC sub-system.
+Name: odbcinst (@PACKAGE_NAME@)
+Description: unixODBC Configuration Library
 URL: http://unixodbc.org
 Version: @PACKAGE_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lodbcinst
+Libs.private: @LIBLTDL@ @LIBS@


### PR DESCRIPTION
When I created the pkg-config templates some time ago, I used generic descriptions. I also neglected static (private) dependency libraries.

Also, the CPP flags are not needed in Cflags output. So, I've moved them to a separate variable, closing #26.