### PR TITLE
Fix buffer length for wide diag recs

### DIFF
--- a/DriverManager/SQLDriverConnect.c
+++ b/DriverManager/SQLDriverConnect.c
@@ -1549,7 +1549,7 @@ SQLRETURN SQLDriverConnect(
                             sqlstate,
                             &native_error,
                             message_text,
-                            sizeof( message_text ),
+                            sizeof( message_text ) / sizeof( SQLWCHAR ),
                             &ind );
 
 
@@ -1590,7 +1590,7 @@ SQLRETURN SQLDriverConnect(
                             sqlstate,
                             &native_error,
                             message_text,
-                            sizeof( message_text ),
+                            sizeof( message_text ) / sizeof( SQLWCHAR ),
                             &ind );
 
 

--- a/DriverManager/SQLDriverConnectW.c
+++ b/DriverManager/SQLDriverConnectW.c
@@ -637,7 +637,7 @@ SQLRETURN SQLDriverConnectW(
                             sqlstate,
                             &native_error,
                             message_text,
-                            sizeof( message_text ),
+                            sizeof( message_text ) / sizeof( SQLWCHAR ),
                             &ind );
 
 
@@ -665,7 +665,7 @@ SQLRETURN SQLDriverConnectW(
                             sqlstate,
                             &native_error,
                             message_text,
-                            sizeof( message_text ),
+                            sizeof( message_text ) / sizeof( SQLWCHAR ),
                             &ind );
 
 


### PR DESCRIPTION
Buffer length for SQLGetDiagRecW and SQLErrorW is in characters, not bytes.
https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdiagrec-function
