### PR TITLE
Simplify driver config module generation

### DIFF
--- a/DRVConfig/Mimer/Makefile.am
+++ b/DRVConfig/Mimer/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libmimerS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libmimerS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+libmimerS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 libmimerS_la_SOURCES = mimerS.c
 	

--- a/DRVConfig/Mimer/Makefile.am
+++ b/DRVConfig/Mimer/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libmimerS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libmimerS_la_LDFLAGS = -no-undefined -version-info 1:0:0 -module
+libmimerS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 libmimerS_la_SOURCES = mimerS.c
 	

--- a/DRVConfig/MiniSQL/Makefile.am
+++ b/DRVConfig/MiniSQL/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcminiS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcminiS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+libodbcminiS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 libodbcminiS_la_SOURCES = odbcminiS.c
 	

--- a/DRVConfig/MiniSQL/Makefile.am
+++ b/DRVConfig/MiniSQL/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcminiS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcminiS_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+libodbcminiS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 libodbcminiS_la_SOURCES = odbcminiS.c
 	

--- a/DRVConfig/MySQL/Makefile.am
+++ b/DRVConfig/MySQL/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcmyS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcmyS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+libodbcmyS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 libodbcmyS_la_SOURCES = odbcmyS.c
 	

--- a/DRVConfig/MySQL/Makefile.am
+++ b/DRVConfig/MySQL/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcmyS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcmyS_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+libodbcmyS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 libodbcmyS_la_SOURCES = odbcmyS.c
 	

--- a/DRVConfig/Oracle/Makefile.am
+++ b/DRVConfig/Oracle/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = liboraodbcS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-liboraodbcS_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+liboraodbcS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 liboraodbcS_la_SOURCES = oraodbcS.c
 	

--- a/DRVConfig/Oracle/Makefile.am
+++ b/DRVConfig/Oracle/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = liboraodbcS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-liboraodbcS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+liboraodbcS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 liboraodbcS_la_SOURCES = oraodbcS.c
 	

--- a/DRVConfig/PostgreSQL/Makefile.am
+++ b/DRVConfig/PostgreSQL/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcpsqlS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcpsqlS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+libodbcpsqlS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 libodbcpsqlS_la_SOURCES = odbcpsqlS.c
 	

--- a/DRVConfig/PostgreSQL/Makefile.am
+++ b/DRVConfig/PostgreSQL/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcpsqlS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcpsqlS_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+libodbcpsqlS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 libodbcpsqlS_la_SOURCES = odbcpsqlS.c
 	

--- a/DRVConfig/drvcfg1/Makefile.am
+++ b/DRVConfig/drvcfg1/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcdrvcfg1S.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcdrvcfg1S_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+libodbcdrvcfg1S_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 libodbcdrvcfg1S_la_SOURCES = drvcfg1.c
 	

--- a/DRVConfig/drvcfg1/Makefile.am
+++ b/DRVConfig/drvcfg1/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcdrvcfg1S.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcdrvcfg1S_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+libodbcdrvcfg1S_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 libodbcdrvcfg1S_la_SOURCES = drvcfg1.c
 	

--- a/DRVConfig/drvcfg2/Makefile.am
+++ b/DRVConfig/drvcfg2/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcdrvcfg2S.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcdrvcfg2S_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+libodbcdrvcfg2S_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 libodbcdrvcfg2S_la_SOURCES = drvcfg2.c
 	

--- a/DRVConfig/drvcfg2/Makefile.am
+++ b/DRVConfig/drvcfg2/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcdrvcfg2S.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcdrvcfg2S_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+libodbcdrvcfg2S_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 libodbcdrvcfg2S_la_SOURCES = drvcfg2.c
 	

--- a/DRVConfig/esoob/Makefile.am
+++ b/DRVConfig/esoob/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libesoobS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libesoobS_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+libesoobS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 libesoobS_la_SOURCES = esoobS.c
 	

--- a/DRVConfig/esoob/Makefile.am
+++ b/DRVConfig/esoob/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libesoobS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libesoobS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+libesoobS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 libesoobS_la_SOURCES = esoobS.c
 	

--- a/DRVConfig/nn/Makefile.am
+++ b/DRVConfig/nn/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcnnS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcnnS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+libodbcnnS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 libodbcnnS_la_SOURCES = drvcfg.c
 	

--- a/DRVConfig/nn/Makefile.am
+++ b/DRVConfig/nn/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbcnnS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbcnnS_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+libodbcnnS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 libodbcnnS_la_SOURCES = drvcfg.c
 	

--- a/DRVConfig/oplodbc/Makefile.am
+++ b/DRVConfig/oplodbc/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = liboplodbcS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-liboplodbcS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+liboplodbcS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 liboplodbcS_la_SOURCES = oplodbc.c
 	

--- a/DRVConfig/oplodbc/Makefile.am
+++ b/DRVConfig/oplodbc/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = liboplodbcS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-liboplodbcS_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+liboplodbcS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 liboplodbcS_la_SOURCES = oplodbc.c
 	

--- a/DRVConfig/sapdb/Makefile.am
+++ b/DRVConfig/sapdb/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libsapdbS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libsapdbS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+libsapdbS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 libsapdbS_la_SOURCES = sapdb.c
 

--- a/DRVConfig/sapdb/Makefile.am
+++ b/DRVConfig/sapdb/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libsapdbS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libsapdbS_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+libsapdbS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 libsapdbS_la_SOURCES = sapdb.c
 

--- a/DRVConfig/tds/Makefile.am
+++ b/DRVConfig/tds/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libtdsS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libtdsS_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+libtdsS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 libtdsS_la_SOURCES = tdsS.c
 	

--- a/DRVConfig/tds/Makefile.am
+++ b/DRVConfig/tds/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libtdsS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libtdsS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+libtdsS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 libtdsS_la_SOURCES = tdsS.c
 	

--- a/DRVConfig/txt/Makefile.am
+++ b/DRVConfig/txt/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbctxtS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbctxtS_la_LDFLAGS = -no-undefined  -version-info 1:0:0 -module
+libodbctxtS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
 
 libodbctxtS_la_SOURCES = drvcfg.c
 	

--- a/DRVConfig/txt/Makefile.am
+++ b/DRVConfig/txt/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libodbctxtS.la
 
 AM_CPPFLAGS = -I@top_srcdir@/include $(LTDLINCL)
 
-libodbctxtS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version
+libodbctxtS_la_LDFLAGS = -module -no-undefined -version-info 1:0:0 -avoid-version -shared
 
 libodbctxtS_la_SOURCES = drvcfg.c
 	


### PR DESCRIPTION
After going through a packaging overhaul for Debian, I realised the driver-config modules are producing the usual three parts:
real soname, fully-qualified soname and symbolic link.

The first patch changes the ldconfig's link mode to generate the soname without soversion. Almost all plugins/dynamic modules are loaded by path, not soversion (as you would with a shared library), so it makes sense to provide the driver module as a single file with no soversion suffix.

The second patch adds `-shared`, which prevents static library generation. Given that driver config modules really should't be static, we don't need to build them. Happy to hear alternative views on this.