### PR TITLE
Add a configure flag allowing users to pass libltdl a custom search path for ODBC modules

### DIFF
--- a/DriverManager/SQLConnect.c
+++ b/DriverManager/SQLConnect.c
@@ -1118,6 +1118,9 @@ int __connect_part_one( DMHDBC connection, char *driver_lib, char *driver_name, 
     mutex_lib_entry();      /* warning, this doesn't protect from other libs in the application */
                             /* in their own threads calling dlinit(); */
     lt_dlinit();
+#ifdef MODULEDIR
+    lt_dlsetsearchpath(MODULEDIR);
+#endif
     mutex_lib_exit();
 
     /*

--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,17 @@ eval "SHLIBEXT=$shrext_cmds"
 AC_MSG_RESULT($SHLIBEXT)
 AC_SUBST(SHLIBEXT,$SHLIBEXT)
 
+dnl Check whether the user specified a path in which libltdl should search for
+dnl ODBC drivers. This search occurs before libltdl tries other paths, such as
+dnl its own default search path or the system library search path.
+dnl
+dnl This option is useful for multi-arch systems such as Debian, which can have
+dnl multiple arch-specific library search paths present on a given system.
+AC_ARG_WITH([odbc-driver-path],
+  [AS_HELP_STRING([--with-odbc-driver-path=DIR], [search for ODBC drivers in DIR at run-time before trying the libltdl and system library search paths])],
+  [AC_DEFINE_UNQUOTED([MODULEDIR], ["`eval echo ${withval}`"], [ODBC driver search path])]
+)
+
 AC_DEFINE_UNQUOTED([SHLIBEXT], "$shrext_cmds", [Shared lib extension])
 AC_DEFINE_DIR([DEFLIB_PATH], [libdir], [Lib directory])
 AC_DEFINE_DIR([LIB_PREFIX], [libdir], [Lib directory])

--- a/odbcinst/ODBCINSTConstructProperties.c
+++ b/odbcinst/ODBCINSTConstructProperties.c
@@ -165,6 +165,9 @@ int ODBCINSTConstructProperties( char *pszDriver, HODBCINSTPROPERTY *hFirstPrope
      */
 
     lt_dlinit();
+#ifdef MODULEDIR
+    lt_dlsetsearchpath(MODULEDIR);
+#endif
 
 	/* TRY GET FUNC FROM DRIVER SETUP */
 	if ( !(hDLL = lt_dlopen( szDriverSetup ))  )

--- a/odbcinst/SQLConfigDataSource.c
+++ b/odbcinst/SQLConfigDataSource.c
@@ -80,6 +80,9 @@ static BOOL SQLConfigDataSourceWide(	HWND	hWnd,
      */
 
     lt_dlinit();
+#ifdef MODULEDIR
+    lt_dlsetsearchpath(MODULEDIR);
+#endif
 
 #ifdef PLATFORM64
 	if ( iniPropertySeek( hIni, (char *)pszDriver, "Setup64", "" ) == INI_SUCCESS || 

--- a/odbcinst/SQLConfigDriver.c
+++ b/odbcinst/SQLConfigDriver.c
@@ -84,6 +84,9 @@ static BOOL SQLConfigDriverWide( HWND	hWnd,
      */
 
     lt_dlinit();
+#ifdef MODULEDIR
+    lt_dlsetsearchpath(MODULEDIR);
+#endif
 
 	/* process request */
 	switch ( nRequest )

--- a/odbcinst/SQLCreateDataSource.c
+++ b/odbcinst/SQLCreateDataSource.c
@@ -232,6 +232,9 @@ BOOL SQLCreateDataSource( HWND hWnd, LPCSTR pszDS )
         inst_logPushMsg( __FILE__, __FILE__, __LINE__, LOG_CRITICAL, ODBC_ERROR_GENERAL_ERR, "lt_dlinit() failed" );
         return FALSE;
     }
+#ifdef MODULEDIR
+    lt_dlsetsearchpath(MODULEDIR);
+#endif
 
     /* get plugin name */
     _appendUIPluginExtension( szNameAndExtension, _getUIPluginName( szName, hODBCInstWnd->szUI ) );

--- a/odbcinst/SQLManageDataSources.c
+++ b/odbcinst/SQLManageDataSources.c
@@ -143,6 +143,9 @@ BOOL SQLManageDataSources( HWND hWnd )
         inst_logPushMsg( __FILE__, __FILE__, __LINE__, LOG_CRITICAL, ODBC_ERROR_GENERAL_ERR, "lt_dlinit() failed" );
 		return FALSE;
     }
+#ifdef MODULEDIR
+    lt_dlsetsearchpath(MODULEDIR);
+#endif
 
     /* get plugin name */
     _appendUIPluginExtension( szNameAndExtension, _getUIPluginName( szName, hODBCInstWnd->szUI ) );


### PR DESCRIPTION
By setting lt_dlsetsearchpath(), libltdl will look in $libdir/odbc before other search paths. This allows Debian and other multi-arch systems to use the correct arch-specific module at compile-time and run-time.