### PR TITLE
Define SIZEOF_LONG_INT using a compiler macro instead of #including unixodbc_conf.h

### DIFF
--- a/include/sqltypes.h
+++ b/include/sqltypes.h
@@ -49,7 +49,7 @@ extern "C" {
  */
 
 #ifndef SIZEOF_LONG_INT
-#include "unixodbc_conf.h"
+#define SIZEOF_LONG_INT __SIZEOF_LONG__
 #endif
 
 #ifndef SIZEOF_LONG_INT


### PR DESCRIPTION
This patch removes the only use of `unixodbc_conf.h` from the headers.

The value of `__SIZEOF_LONG__` is determined at compile-time, depending on the system arch. For 64-bit systems, it will #define as 8.

It's a handy macro, which is supported by (at least) gcc and clang.