### PR TITLE
Add connection pool limit option

### DIFF
--- a/DriverManager/SQLAllocHandle.c
+++ b/DriverManager/SQLAllocHandle.c
@@ -259,6 +259,9 @@ static char const rcsid[]= "$RCSfile: SQLAllocHandle.c,v $ $Revision: 1.13 $";
  */
 
 extern int pooling_enabled;
+extern int pool_max_size;
+extern int pool_wait_timeout;
+
 
 /*
  * this is used so that it can be called without falling
@@ -277,6 +280,8 @@ SQLRETURN __SQLAllocHandle( SQLSMALLINT handle_type,
         {
             DMHENV environment;
             char pooling_string[ 128 ];
+            char pool_max_size_string [ 128 ];
+            char pool_wait_timeout_string [ 128 ];
 
             if ( !output_handle ) 
             {
@@ -306,6 +311,19 @@ SQLRETURN __SQLAllocHandle( SQLSMALLINT handle_type,
             else
             {
                 pooling_enabled = 0;
+            }
+
+            if ( pooling_enabled )
+            {
+                SQLGetPrivateProfileString( "ODBC", "PoolMaxSize", "0",
+                    pool_max_size_string, sizeof( pool_max_size_string ),
+                    "ODBCINST.INI" );
+                pool_max_size = atoi( pool_max_size_string );
+
+                SQLGetPrivateProfileString( "ODBC", "PoolWaitTimeout", "30",
+                    pool_wait_timeout_string, sizeof( pool_wait_timeout_string ),
+                    "ODBCINST.INI" );
+                pool_wait_timeout = atoi( pool_wait_timeout_string );
             }
 
             if ( !( environment = __alloc_env()))

--- a/DriverManager/SQLDisconnect.c
+++ b/DriverManager/SQLDisconnect.c
@@ -284,29 +284,8 @@ SQLRETURN SQLDisconnect( SQLHDBC connection_handle )
      * is it a pooled connection, or can it go back 
      */
 
-    if ( connection -> pooled_connection )
-    {
-        __clean_stmt_from_dbc( connection );
-        __clean_desc_from_dbc( connection );
-
-        return_to_pool( connection );
-
-        if ( log_info.log_flag )
-        {
-            sprintf( connection -> msg, 
-                    "\n\t\tExit:[%s]",
-                        __get_return_status( SQL_SUCCESS, s1 ));
-
-            dm_log_write( __FILE__, 
-                    __LINE__, 
-                    LOG_INFO, 
-                    LOG_INFO, 
-                    connection -> msg );
-        }
-
-        return function_return_nodrv( SQL_HANDLE_DBC, connection, SQL_SUCCESS );
-    }
-    else if ( pooling_enabled && connection -> pooling_timeout > 0 ) 
+    if ( connection -> pooled_connection ||
+         pooling_enabled && connection -> pooling_timeout > 0 )
     {
         __clean_stmt_from_dbc( connection );
         __clean_desc_from_dbc( connection );

--- a/DriverManager/__info.c
+++ b/DriverManager/__info.c
@@ -5648,6 +5648,13 @@ void __post_internal_error_api( EHEAD *error_handle,
         message = "General error";
         break;
 
+      case ERROR_HYT02:
+        strcpy( sqlstate, "HYT02");
+        message = "Connection pool at capacity and the wait has timed out";
+        subclass = SUBCLASS_ODBC;
+        class = SUBCLASS_ODBC;
+        break;
+
 	  default:
         strcpy( sqlstate, "?????" );
         message = "Unknown";

--- a/DriverManager/drivermanager.h
+++ b/DriverManager/drivermanager.h
@@ -408,8 +408,24 @@ typedef struct connection
 	SQLSMALLINT		crb_value;
 } *DMHDBC;
 
-typedef struct connection_pool
+struct connection_pool_head;
+
+typedef struct connection_pool_entry
 {
+    time_t  expiry_time;
+    int     ttl;
+    int     timeout;
+    int     in_use;
+    struct  connection_pool_entry *next;
+    struct  connection_pool_head *head;
+    struct  connection connection;
+    int     cursors;
+} CPOOLENT;
+
+typedef struct connection_pool_head
+{
+    struct connection_pool_head *next;
+
     char    driver_connect_string[ 1024 ];
     int     dsn_length;
     char    server[ 128 ];
@@ -418,14 +434,11 @@ typedef struct connection_pool
     int     user_length;
     char    password[ 128 ];
     int     password_length;
-    time_t  expiry_time;
-    int     ttl;
-    int     timeout;
-    int     in_use;
-    struct  connection_pool *next;
-    struct  connection connection;
-    int     cursors;
-} CPOOL;
+
+    int     num_entries;                /* always at least 1 */
+    CPOOLENT *entries;
+} CPOOLHEAD;
+
 
 typedef struct descriptor
 {
@@ -659,7 +672,8 @@ typedef enum error_id
     ERROR_SL010,
     ERROR_SL008,
     ERROR_HY000,
-    ERROR_IM011
+    ERROR_IM011,
+    ERROR_HYT02
 } error_id;
 
 #define IGNORE_THREAD       (-1)
@@ -787,6 +801,8 @@ struct driver_helper_funcs
 
 void thread_protect( int type, void *handle );
 void thread_release( int type, void *handle );
+int pool_timedwait( DMHDBC );
+void pool_signal();
 
 #else
 
@@ -916,9 +932,13 @@ int search_for_pool( DMHDBC connection,
            SQLCHAR *authentication,
            SQLSMALLINT name_length3,
            SQLCHAR *connect_string,
-           SQLSMALLINT connect_string_length );
+           SQLSMALLINT connect_string_length,
+           CPOOLHEAD **pooh,
+           int retrying );
 
 void return_to_pool( DMHDBC connection );
+
+int add_to_pool( DMHDBC connection, CPOOLHEAD *pooh );
 
 /*
  * Macros to check and call functions in the driver


### PR DESCRIPTION
This is the outcome of the discussion in #42 . It implements a configurable limit for the number of active connections per same connection string when pooling is enabled. When the limit is reached, SQLConnect/W and SQLDriverConnect/W will block until either a connection becomes available, or the configurable timeout is reached. If the latter occurs, an error is returned to the application.

The configuration options are in the [ODBC] section of odbcinst.ini and consist of MaxPoolSize (default 0 = no limit) and PoolWaitTimeout (default 30 seconds).