### PR TITLE
Fix grouping for latest doxygen.

### DIFF
--- a/include/sqlext.h
+++ b/include/sqlext.h
@@ -2137,7 +2137,7 @@ SQLRETURN SQL_API SQLSetScrollOptions(    /*      Use SQLSetStmtOptions */
  *              odbctxt
  *              odbctrac
  */
-/*@{*/
+/**@{*/
 #define	TRACE_VERSION 1000                                  /*!< Version of trace API                               */
 #ifdef UNICODE
 RETCODE TraceOpenLogFile(SQLPOINTER,LPWSTR,LPWSTR,DWORD); 	/*!< open a trace log file				                */
@@ -2180,7 +2180,7 @@ typedef struct tagODBC_VS_ARGS {
 } ODBC_VS_ARGS, *PODBC_VS_ARGS;
 
 void	FireVSDebugEvent(PODBC_VS_ARGS);
-/*@}*/
+/**@}*/
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Since doxygen 1.8.16, opening and closing a group must not be done as C comment but as doxygen command. In other words, not one but two asterisk characters are required so that doxygen finds a group.