### PR TITLE
Move ltdl.h from public header to where it is used.

### DIFF
--- a/include/odbcinstext.h
+++ b/include/odbcinstext.h
@@ -14,7 +14,6 @@
 
 #ifdef UNIXODBC_SOURCE
 
-#include <ltdl.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -24,7 +23,6 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#include <stdio.h>
 
 #ifndef ODBCVER
 #define ODBCVER 0x0380

--- a/odbcinst/ODBCINSTConstructProperties.c
+++ b/odbcinst/ODBCINSTConstructProperties.c
@@ -10,6 +10,11 @@
  * Peter Harvey		- pharvey@codebydesign.com
  **************************************************/
 #include <config.h>
+
+#ifdef UNIXODBC_SOURCE
+#include <ltdl.h>
+#endif
+
 #include <odbcinstext.h>
 
 /*

--- a/odbcinst/ODBCINSTDestructProperties.c
+++ b/odbcinst/ODBCINSTDestructProperties.c
@@ -10,6 +10,11 @@
  * Peter Harvey		- pharvey@codebydesign.com
  **************************************************/
 #include <config.h>
+
+#ifdef UNIXODBC_SOURCE
+#include <ltdl.h>
+#endif
+
 #include <odbcinstext.h>
 
 int ODBCINSTDestructProperties( HODBCINSTPROPERTY *hFirstProperty )

--- a/odbcinst/SQLConfigDataSource.c
+++ b/odbcinst/SQLConfigDataSource.c
@@ -13,6 +13,11 @@
  * Peter Harvey		- pharvey@codebydesign.com
  **************************************************/
 #include <config.h>
+
+#ifdef UNIXODBC_SOURCE
+#include <ltdl.h>
+#endif
+
 #include <odbcinstext.h>
 
 static BOOL SQLConfigDataSourceWide(	HWND	hWnd,

--- a/odbcinst/SQLConfigDriver.c
+++ b/odbcinst/SQLConfigDriver.c
@@ -10,6 +10,11 @@
  * Peter Harvey		- pharvey@codebydesign.com
  **************************************************/
 #include <config.h>
+
+#ifdef UNIXODBC_SOURCE
+#include <ltdl.h>
+#endif
+
 #include <odbcinstext.h>
 
 static BOOL SQLConfigDriverWide( HWND	hWnd,

--- a/odbcinst/SQLCreateDataSource.c
+++ b/odbcinst/SQLCreateDataSource.c
@@ -13,6 +13,11 @@
  * Peter Harvey		- pharvey@codebydesign.com
  **************************************************/
 #include <config.h>
+
+#ifdef UNIXODBC_SOURCE
+#include <ltdl.h>
+#endif
+
 #include <odbcinstext.h>
 
 /*

--- a/odbcinst/SQLManageDataSources.c
+++ b/odbcinst/SQLManageDataSources.c
@@ -10,6 +10,11 @@
  * Peter Harvey		- pharvey@codebydesign.com
  **************************************************/
 #include <config.h>
+
+#ifdef UNIXODBC_SOURCE
+#include <ltdl.h>
+#endif
+
 #include <odbcinstext.h>
 
 /*! 

--- a/odbcinst/_SQLDriverConnectPrompt.c
+++ b/odbcinst/_SQLDriverConnectPrompt.c
@@ -1,4 +1,9 @@
 #include <config.h>
+
+#ifdef UNIXODBC_SOURCE
+#include <ltdl.h>
+#endif
+
 #include <odbcinstext.h>
 
 BOOL _SQLDriverConnectPrompt( 


### PR DESCRIPTION
This is a bit longer story. I am coming downstream from the Linux distribution Ubuntu and its Debian package [unixodbc-dev](https://packages.ubuntu.com/focal/unixodbc-dev), a developer package containing the static library, the shared library, and the public header files, to build an application (in my case Digium Asterisk) with unixODBC. That package depends on its runtime library and, therefore, on its runtime package `libodbc1`. That in turn depends on `libltdl7` because symbols are used from that. So far, so good.

However, the developer package depends, actually requires, the package `libltdl-dev` as well. I guess, this happens because a public header in the package `unixodbc-dev` is including an header of the package `libltdl-dev`. And indeed, `odbcinstext.h` includes `ltdl.h`. Then, I investigated with
```
$ cd ./include/
$ include-what-you-use -DUNIXODBC_SOURCE=1 odbcinstext.h
```
and iwyu told me that `ltdl.h` is not used by this header. I double-checked by searching for a symbol starting with `lt_`, and nothing was found. Then, I made the code and found seven sources that require `ltdl.h`. See the attached commit for the files affected.

**Long story short:**
This Pull Request moves the inclusion down to the actual use(r) of the header, the runtime library. I am not sure whether this change is accepted because it makes no difference for the upstream project, this project here. My goal, my main goal, is to start a discussion (or ask for an explanation): What are the *public* headers of unixODBC? That puzzle piece of information is required for the maintainer of the package unixodbc-dev. That define `UNIXODBC_SOURCE` sounds like some parts of `odbcinstext.h` are not public actually. Or is `odbcinstext.h` in general not public? I do not think so but not sure. Therefore, I would kindly ask for support = clarification.