### PR TITLE
DriverManager/drivermanager.h: fix build without threads

### DIFF
--- a/DriverManager/drivermanager.h
+++ b/DriverManager/drivermanager.h
@@ -808,6 +808,8 @@ void pool_signal();
 
 #define thread_protect(a,b)
 #define thread_release(a,b)
+#define pool_timedwait(a)
+#define pool_signal()
 
 #endif
 


### PR DESCRIPTION
Fix the following build failure without threads raised since version 2.3.10 and commit 6df155fb213896b9507b421c58856e4376647ae1:

```
/home/buildroot/autobuild/run/instance-2/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabihf/9.3.0/../../../../arm-buildroot-linux-uclibcgnueabihf/bin/ld: ../DriverManager/.libs/libodbc.so: undefined reference to `pool_timedwait'
/home/buildroot/autobuild/run/instance-2/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabihf/9.3.0/../../../../arm-buildroot-linux-uclibcgnueabihf/bin/ld: ../DriverManager/.libs/libodbc.so: undefined reference to `pool_signal'
```

Fixes:
 - http://autobuild.buildroot.org/results/131eafaddfc956c7d54c81ed72a31baf28ab1ab6

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>