### PR TITLE
Initialize driver_name buffer in DriverManager/SQLBrowseConnect

### DIFF
--- a/DriverManager/SQLBrowseConnect.c
+++ b/DriverManager/SQLBrowseConnect.c
@@ -206,7 +206,7 @@ SQLRETURN SQLBrowseConnect(
     struct con_struct con_struct;
     char *driver, *dsn;
     char lib_name[ INI_MAX_PROPERTY_VALUE + 1 ];
-    char driver_name[ INI_MAX_PROPERTY_VALUE + 1 ];
+    char driver_name[ INI_MAX_PROPERTY_VALUE + 1 ] = { 0 };
     char in_str_buf[ BUFFER_LEN ];
     char *in_str;
     SQLSMALLINT in_str_len;


### PR DESCRIPTION
I was testing my odbc driver under Valgrind and it triggered on an uninitialized read in libunixodbc itself.
Here's a quick fix, there may be other instances of the same problem.

Sometimes __find_lib_name returns non-NULL without writing anything to _driver_name_ and then it's passed to __connect_part_one without further initialization.