### PR TITLE
fix potential NULL pointer dereference found by cppcheck

### DIFF
--- a/Drivers/Postgre7.1/connection.c
+++ b/Drivers/Postgre7.1/connection.c
@@ -995,6 +995,9 @@ static char msgbuffer[MAX_MESSAGE_LEN+1];
 char cmdbuffer[MAX_MESSAGE_LEN+1];	/* QR_set_command() dups this string so dont need static */
 
 
+	if ((NULL == query) || (query[0] == '\0'))
+		return NULL;
+
 	mylog("send_query(): conn=%u, query='%s'\n", self, query);
 	qlog("conn=%u, query='%s'\n", self, query);
 
@@ -1003,9 +1006,6 @@ char cmdbuffer[MAX_MESSAGE_LEN+1];	/* QR_set_command() dups this string so dont 
 		CC_set_error(self, CONNECTION_MSG_TOO_LONG, "Query string is too long");
 		return NULL;
 	}
-
-	if ((NULL == query) || (query[0] == '\0'))
-		return NULL;
 
 	if (SOCK_get_errcode(sock) != 0) {
 		CC_set_error(self, CONNECTION_COULD_NOT_SEND, "Could not send Query to backend");


### PR DESCRIPTION
Drivers/Postgre7.1/connection.c:1002:12: warning: Either the condition 'NULL==query' is redundant or there is possible null pointer dereference: query. [nullPointerRedundantCheck]