### PR TITLE
fix potential NULL pointer dereference found by cppcheck

### DIFF
--- a/DriverManager/SQLConnect.c
+++ b/DriverManager/SQLConnect.c
@@ -4566,8 +4566,8 @@ retry:
                         as1 = (SQLCHAR *) unicode_to_ansi_alloc( sqlstate, SQL_NTS, connection, NULL );
                         as2 = (SQLCHAR *) unicode_to_ansi_alloc( message_text, SQL_NTS, connection, NULL );
 
-                        sprintf( connection -> msg, "\t\tDIAG [%s] %s",
-                                as1, as2 );
+                        if ( as1 && as2 ) 
+                                sprintf( connection -> msg, "\t\tDIAG [%s] %s", as1, as2 );
 
                         if ( as1 ) free( as1 );
                         if ( as2 ) free( as2 );
@@ -4607,8 +4607,8 @@ retry:
                         as1 = (SQLCHAR *) unicode_to_ansi_alloc( sqlstate, SQL_NTS, connection, NULL );
                         as2 = (SQLCHAR *) unicode_to_ansi_alloc( message_text, SQL_NTS, connection, NULL );
 
-                        sprintf( connection -> msg, "\t\tDIAG [%s] %s",
-                                as1, as2 );
+                        if (as1 && as2)
+                                sprintf( connection -> msg, "\t\tDIAG [%s] %s", as1, as2 );
 
                         if ( as1 ) free( as1 );
                         if ( as2 ) free( as2 );


### PR DESCRIPTION
DriverManager/SQLConnect.c:4570:33: warning: Either the condition 'as1' is redundant or there is possible null pointer dereference: as1. [nullPointerRedundantCheck]
DriverManager/SQLConnect.c:4570:38: warning: Either the condition 'as2' is redundant or there is possible null pointer dereference: as2. [nullPointerRedundantCheck]
DriverManager/SQLConnect.c:4611:33: warning: Either the condition 'as1' is redundant or there is possible null pointer dereference: as1. [nullPointerRedundantCheck]
DriverManager/SQLConnect.c:4611:38: warning: Either the condition 'as2' is redundant or there is possible null pointer dereference: as2. [nullPointerRedundantCheck]