### PR TITLE
drop "strncasecmp" emulation

### DIFF
--- a/extras/strcasecmp.c
+++ b/extras/strcasecmp.c
@@ -26,35 +26,6 @@ int strcasecmp( const char *s1, const char * s2 )
 }
 
 #endif
-#ifndef HAVE_STRNCASECMP
-
-int strncasecmp (const char *s1, const char *s2, int n )
-{
-    const unsigned char *p1 = (const unsigned char *) s1;
-    const unsigned char *p2 = (const unsigned char *) s2;
-    unsigned char c1, c2;
-
-    if (p1 == p2)
-        return 0;
-
-    do
-    {
-        c1 = tolower(*p1++);
-        c2 = tolower(*p2++);
-        if (c1 == '\0')
-            break;
-
-        n --;
-    }
-    while (c1 == c2 && n > 0 );
-
-    if ( n == 0 )
-        return 0;
-
-    return c1 - c2;
-}
-
-#endif
 
 void ___extra_func_to_mollify_linker( void )
 {

--- a/include/uodbc_extras.h
+++ b/include/uodbc_extras.h
@@ -72,11 +72,6 @@ extern int uodbc_vsnprintf (char *str, size_t count, const char *fmt, va_list ar
 extern int strcasecmp( const char *s1, const char * s2 );
 #endif
 
-#ifndef HAVE_STRNCASECMP
-extern int strncasecmp (const char *s1, const char *s2, int n );
-#endif
-
-
 #if defined(__cplusplus)
          }
 #endif

--- a/unixodbc_conf.h.in
+++ b/unixodbc_conf.h.in
@@ -272,9 +272,6 @@
 /* Define to 1 if you have the `strlcpy' function. */
 #undef HAVE_STRLCPY
 
-/* Define to 1 if you have the `strncasecmp' function. */
-#undef HAVE_STRNCASECMP
-
 /* Define to 1 if you have the `strnicmp' function. */
 #undef HAVE_STRNICMP
 


### PR DESCRIPTION
forgive me if I'm wrong on that.

when I compile with "treat warning as errors" mode:

```
strcasecmp.c:31:5: error: conflicting types for built-in function 'strncasecmp'; expected 'int(const char *, const char *, long unsigned int)' [-Werror=builtin-declaration-mismatch]
   31 | int strncasecmp (const char *s1, const char *s2, int n )
      |     ^~~~~~~~~~~
cc1: all warnings being treated as errors
```

as I see in "configure" strncasecmp is mandatory. from that point of view I'd drop its definition for good