### PR TITLE
fix potential memory overflow

### DIFF
--- a/DriverManager/SQLConnect.c
+++ b/DriverManager/SQLConnect.c
@@ -2445,7 +2445,7 @@ int __connect_part_two( DMHDBC connection )
 #endif
             if ( !(connection -> cl_handle = odbc_dlopen( name, &err )))
             {
-                char txt[ 1024 ];
+                char txt[ ODBC_FILENAME_MAX * 2 + 45 ];
 
 #ifdef HAVE_SNPRINTF
                 snprintf( txt, sizeof( txt ), "Can't open cursor lib '%s' : %s", 

--- a/DriverManager/SQLConnect.c
+++ b/DriverManager/SQLConnect.c
@@ -965,7 +965,7 @@ int __connect_part_one( DMHDBC connection, char *driver_lib, char *driver_name, 
     int fake_unicode;
     char *err;
     struct env_lib_struct *env_lib_list, *env_lib_prev;
-    char txt[ 256 ];
+    char txt[ 531 ];
 
     /*
      * check to see if we want to alter the default threading level

--- a/DriverManager/SQLDrivers.c
+++ b/DriverManager/SQLDrivers.c
@@ -370,7 +370,7 @@ try_again:
             char szPropertyName[INI_MAX_PROPERTY_NAME+1];
             char szValue[INI_MAX_PROPERTY_NAME+1];
             char szIniName[ INI_MAX_OBJECT_NAME + 1 ];
-            char buffer[ 1024 ];
+            char buffer[ 2 * INI_MAX_PROPERTY_NAME + 3 ];
             int total_len = 0;
             char b1[ ODBC_FILENAME_MAX + 1 ], b2[ ODBC_FILENAME_MAX + 1 ];
             int found = 0;

--- a/DriverManager/SQLDriversW.c
+++ b/DriverManager/SQLDriversW.c
@@ -294,7 +294,7 @@ try_again:
             char szPropertyName[INI_MAX_PROPERTY_NAME+1];
             char szValue[INI_MAX_PROPERTY_NAME+1];
             char szIniName[ INI_MAX_OBJECT_NAME + 1 ];
-            char buffer[ 1024 ];
+            char buffer[ 2 * INI_MAX_OBJECT_NAME + 3 ];
             int total_len = 0;
             char b1[ ODBC_FILENAME_MAX + 1 ], b2[ ODBC_FILENAME_MAX + 1 ];
             int found = 0;

--- a/odbcinst/SQLReadFileDSN.c
+++ b/odbcinst/SQLReadFileDSN.c
@@ -88,7 +88,7 @@ BOOL SQLReadFileDSN(            LPCSTR  pszFileName,
 {
     HINI    hIni;
     char    szValue[INI_MAX_PROPERTY_VALUE+1];
-    char    szFileName[ODBC_FILENAME_MAX+1];
+    char    szFileName[ODBC_FILENAME_MAX+2];
 
     inst_logClear();
 

--- a/odbcinst/SQLWriteFileDSN.c
+++ b/odbcinst/SQLWriteFileDSN.c
@@ -17,7 +17,7 @@ BOOL SQLWriteFileDSN(			LPCSTR	pszFileName,
 								LPCSTR	pszString )
 {
 	HINI	hIni;
-	char	szFileName[ODBC_FILENAME_MAX+1];
+	char	szFileName[ODBC_FILENAME_MAX+7];
 
     if ( pszFileName == NULL ) 
     {


### PR DESCRIPTION
found by -Wformat-overflow flag

SQLConnect.c:1105:44: warning: '%s' directive writing up to 511 bytes into a region of size 238 [-Wformat-overflow=]
 1105 |         sprintf( txt, "\t\tCPProbe set to '%s'", connection -> probe_sql );
      |                                            ^~