### PR TITLE
fix potential null deref found by cppcheck

### DIFF
--- a/DriverManager/__info.c
+++ b/DriverManager/__info.c
@@ -4925,7 +4925,7 @@ void extract_diag_error_w( int htype,
                 as2 = (SQLCHAR*) unicode_to_ansi_alloc( msg1, SQL_NTS, connection, NULL );
 
                 sprintf( connection -> msg, "\t\tDIAG [%s] %s",
-                        as1, as2 );
+                        as1 ? as1 : "NULL", as2 ? as2 : "NULL" );
 
                 if( as1 ) free( as1 );
                 if( as2 ) free( as2 );
@@ -5037,7 +5037,7 @@ void extract_sql_error_w( DRV_SQLHANDLE henv,
                 as2 = (SQLCHAR*) unicode_to_ansi_alloc( msg1, SQL_NTS, connection, NULL );
 
                 sprintf( connection -> msg, "\t\tDIAG [%s] %s",
-                        as1, as2 );
+                        as1 ? as1 : "NULL", as2 ? as2 : "NULL");
 
                 if( as1 ) free( as1 );
                 if( as2 ) free( as2 );


### PR DESCRIPTION
DriverManager/__info.c:4928:25: warning: Either the condition 'as1' is redundant or there is possible null pointer dereference: as1. [nullPointerRedundantCheck]
DriverManager/__info.c:4928:30: warning: Either the condition 'as2' is redundant or there is possible null pointer dereference: as2. [nullPointerRedundantCheck]
DriverManager/__info.c:5040:25: warning: Either the condition 'as1' is redundant or there is possible null pointer dereference: as1. [nullPointerRedundantCheck]
DriverManager/__info.c:5040:30: warning: Either the condition 'as2' is redundant or there is possible null pointer dereference: as2. [nullPointerRedundantCheck]