### PR TITLE
cleanup: remove redundant condition

### DIFF
--- a/DriverManager/SQLGetDiagField.c
+++ b/DriverManager/SQLGetDiagField.c
@@ -580,10 +580,7 @@ static SQLRETURN extract_sql_error_field( EHEAD *head,
                  * map 3 to 2 if required
                  */
                 if ( diag_info_ptr )
-                {
-                    if ( diag_info_ptr )
-                        __map_error_state( diag_info_ptr, __get_version( head ));
-                }
+                    __map_error_state( diag_info_ptr, __get_version( head ));
             }
 
             return ret;
@@ -608,10 +605,7 @@ static SQLRETURN extract_sql_error_field( EHEAD *head,
                  * map 3 to 2 if required
                  */
                 if ( diag_info_ptr )
-                {
-                    if ( diag_info_ptr )
-                        __map_error_state( diag_info_ptr, __get_version( head ));
-                }
+                    __map_error_state( diag_info_ptr, __get_version( head ));
             }
 
             return ret;


### PR DESCRIPTION
DriverManager/SQLGetDiagField.c:584:26: warning: Identical inner 'if' condition is always true. [identicalInnerCondition]
DriverManager/SQLGetDiagField.c:612:26: warning: Identical inner 'if' condition is always true. [identicalInnerCondition]