### PR TITLE
fix potential null pointer dereference found by coverity

### DIFF
--- a/cur/SQLConnect.c
+++ b/cur/SQLConnect.c
@@ -418,8 +418,9 @@ SQLRETURN CLDisconnect( SQLHDBC connection_handle )
      * disconnect from the driver
      */
 
-    ret = SQLDISCONNECT( cl_connection, 
-            cl_connection -> driver_dbc );
+    ret = cl_connection -> functions ?
+            SQLDISCONNECT( cl_connection, cl_connection -> driver_dbc ) :
+            -1;
 
     if ( SQL_SUCCEEDED( ret ))
     {


### PR DESCRIPTION
CID 442404: (#1 of 1): Dereference before null check (REVERSE_INULL) check_after_deref: Null-checking cl_connection->functions suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
452        if ( cl_connection -> functions ) {
453            free( cl_connection -> functions );
454        }
455
456        free( cl_connection );