### PR TITLE
fix potential null pointer dereference found by coverity

### DIFF
--- a/DriverManager/drivermanager.h
+++ b/DriverManager/drivermanager.h
@@ -1176,7 +1176,7 @@ int add_to_pool( DMHDBC connection, CPOOLHEAD *pooh );
                                         (stmt,pn,dtp,psp,ddp,np)
 
 #define DM_SQLDISCONNECT            21
-#define CHECK_SQLDISCONNECT(con)    (con->functions[21].func!=NULL)
+#define CHECK_SQLDISCONNECT(con)    (con->functions!=NULL && con->functions[21].func!=NULL)
 #define SQLDISCONNECT(con,dbc)\
                                     ((SQLRETURN (*)(SQLHDBC))\
                                     con->functions[21].func)(dbc)


### PR DESCRIPTION
CID 442459: (#2 of 2): Dereference before null check (REVERSE_INULL) check_after_deref: Null-checking conn->functions suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
3048        if ( conn -> functions )
3049        {
3050            free( conn -> functions );
3051            conn -> functions = NULL;
3052        }