### PR TITLE
fix potential null pointer dereference found by coverity

### DIFF
--- a/odbcinst/SQLWriteFileDSN.c
+++ b/odbcinst/SQLWriteFileDSN.c
@@ -116,7 +116,7 @@ BOOL INSTAPI SQLWriteFileDSNW(LPCWSTR  lpszFileName,
 	key = lpszKeyName ? _single_string_alloc_and_copy( lpszKeyName ) : (char*)NULL;
 	str = lpszString ? _single_string_alloc_and_copy( lpszString ) : (char*)NULL;
 
-	ret = SQLWriteFileDSN( file, app, key, str );
+	ret = app ? SQLWriteFileDSN( file, app, key, str ) : FALSE;
 
 	if ( file )
 		free( file );


### PR DESCRIPTION
CID 442478: (#undefined of undefined): Explicit null dereferenced (FORWARD_NULL)
6. var_deref_model: Passing null pointer app to SQLWriteFileDSN, which dereferences it.[show details]
119        ret = SQLWriteFileDSN( file, app, key, str );