### PR TITLE
fix potential null pointer deref found by coverity

### DIFF
--- a/odbcinst/SQLInstallDriverEx.c
+++ b/odbcinst/SQLInstallDriverEx.c
@@ -248,7 +248,7 @@ BOOL INSTAPI SQLInstallDriverExW(LPCWSTR lpszDriver,
 		pout = NULL;
 	}
 
-	ret = SQLInstallDriverEx( drv, pth, pout, cbPathOutMax, &len, fRequest, lpdwUsageCount );
+	ret = pout ? SQLInstallDriverEx( drv, pth, pout, cbPathOutMax, &len, fRequest, lpdwUsageCount ) : FALSE;
 
 	if ( ret )
 	{


### PR DESCRIPTION
CID 442487: (#1 of 1): Explicit null dereferenced (FORWARD_NULL)
5. var_deref_model: Passing null pointer pout to SQLInstallDriverEx, which dereferences it. [Note: The source code implementation of the function has been overridden by a builtin model.]
251        ret = SQLInstallDriverEx( drv, pth, pout, cbPathOutMax, &len, fRequest, lpdwUsageCount );