### PR TITLE
fix potential null pointer dereference found by coverity

### DIFF
--- a/exe/isql.c
+++ b/exe/isql.c
@@ -208,7 +208,7 @@ int main( int argc, char *argv[] )
      * CONNECT
      ***************************/
 
-    if ( !OpenDatabase( &hEnv, &hDbc, szDSN, szUID, szPWD ) )
+    if (szPWD==NULL || szUID==NULL || !OpenDatabase( &hEnv, &hDbc, szDSN, szUID, szPWD ))
         exit( 1 );
 
     /****************************


### PR DESCRIPTION
CID 442531: (#undefined of undefined): Explicit null dereferenced (FORWARD_NULL)
35. var_deref_model: Passing null pointer szPWD to OpenDatabase, which dereferences it.[show details]

CID 442534: (#1 of 1): Explicit null dereferenced (FORWARD_NULL)
36. var_deref_model: Passing null pointer szUID to OpenDatabase, which dereferences it.[show details]

211    if ( !OpenDatabase( &hEnv, &hDbc, szDSN, szUID, szPWD ) )