### PR TITLE
fix potential null pointer deref found by coverity

### DIFF
--- a/odbcinst/SQLGetPrivateProfileString.c
+++ b/odbcinst/SQLGetPrivateProfileString.c
@@ -642,7 +642,7 @@ int  INSTAPI SQLGetPrivateProfileStringW( LPCWSTR lpszSection,
 		buf = NULL;
 	}
 
-	ret = SQLGetPrivateProfileString( sect, entry, def, buf, cbRetBuffer, name );
+	ret = buf ? SQLGetPrivateProfileString( sect, entry, def, buf, cbRetBuffer, name ) : -1;
 
 	if ( sect )
 		free( sect );


### PR DESCRIPTION
CID 442541: (#2 of 2): Explicit null dereferenced (FORWARD_NULL)
7. var_deref_model: Passing null pointer buf to SQLGetPrivateProfileString, which dereferences it. [Note: The source code implementation of the function has been overridden by a builtin model.] CID 442541:(#1 of 2):Explicit null dereferenced (FORWARD_NULL) [ "select issue" ]
645        ret = SQLGetPrivateProfileString( sect, entry, def, buf, cbRetBuffer, name );