### PR TITLE
fix double lock

### DIFF
--- a/DriverManager/SQLFetch.c
+++ b/DriverManager/SQLFetch.c
@@ -169,7 +169,10 @@ SQLRETURN SQLFetch( SQLHSTMT statement_handle )
      * check states
      */
 
-    thread_protect( SQL_HANDLE_STMT, statement );
+    if (SQL_HANDLE_STMT != IGNORE_THREAD)
+    {
+        thread_protect( SQL_HANDLE_STMT, statement );
+    }
 
     if ( statement -> state == STATE_S1 ||
             statement -> state == STATE_S2 ||


### PR DESCRIPTION
found by coverity

 754
       2. lock: SQLFetch locks hStmt->mutex.[show details]
       3. Condition (ret = SQLFetch(hStmt)) == 0, taking false branch.
      CID 442426:(#2 of 4):Double lock (LOCK) [ "select issue" ]
 755    while ( (ret = SQLFetch( hStmt )) == SQL_SUCCESS ) /* ROWS */