### PR TITLE
fix potential leak found by coverity

### DIFF
--- a/DriverManager/SQLDriverConnect.c
+++ b/DriverManager/SQLDriverConnect.c
@@ -466,7 +466,12 @@ struct con_pair * con_p;
     {
         con_p = malloc( sizeof( *con_p ));
         if ( !con_p )
+        {
+            free(keyword);
+            if ( value )
+                free(value);
             return NULL;
+        }
         con_p -> keyword = keyword;
         con_p -> attribute = value;
         return con_p;


### PR DESCRIPTION
*** CID 446774:  Resource leaks  (RESOURCE_LEAK)
/DriverManager/SQLDriverConnect.c: 469 in __get_pair() 463
464         __get_attr( cp, &keyword, &value );
465         if ( keyword )
466         {
467             con_p = malloc( sizeof( *con_p ));
468             if ( !con_p )
>>>     CID 446774:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "value" going out of scope leaks the storage it points to.
469                 return NULL;
470             con_p -> keyword = keyword;
471             con_p -> attribute = value;
472             return con_p;
473         }
474         else

*** CID 446773:  Resource leaks  (RESOURCE_LEAK)
/DriverManager/SQLDriverConnect.c: 469 in __get_pair() 463
464         __get_attr( cp, &keyword, &value );
465         if ( keyword )
466         {
467             con_p = malloc( sizeof( *con_p ));
468             if ( !con_p )
>>>     CID 446773:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "keyword" going out of scope leaks the storage it points to.
469                 return NULL;
470             con_p -> keyword = keyword;
471             con_p -> attribute = value;
472             return con_p;
473         }
474         else