### PR TITLE
Add LIBICONV to odbc.pc.in

### DIFF
--- a/DriverManager/odbc.pc.in
+++ b/DriverManager/odbc.pc.in
@@ -17,4 +17,4 @@ URL: http://unixodbc.org
 Version: @PACKAGE_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lodbc
-Libs.private: @LIBLTDL@ @LIBS@
+Libs.private: @LIBLTDL@ @LIBICONV@ @LIBS@


### PR DESCRIPTION
With static library linkage, LIBICONV becomes a transitive usage requirement, so it must go to Libs.private.

Noticed while updating the vcpkg port.
