### PR TITLE
Fix: Handle uncommitted transactions in pooled disconnect (Fixes #230)

### DIFF
--- a/DriverManager/SQLConnect.c
+++ b/DriverManager/SQLConnect.c
@@ -2920,6 +2920,7 @@ static void close_pooled_connection( CPOOLENT *ptr )
 {
     SQLRETURN ret;
     DMHDBC conn = &ptr -> connection;
+    SQLCHAR s1[ 100 + LOG_MESSAGE_LEN ];
 
     if ( conn -> driver_dbc == NULL ) {
         return;
@@ -2935,6 +2936,41 @@ static void close_pooled_connection( CPOOLENT *ptr )
     }
 
     ret = SQLDISCONNECT( conn, conn -> driver_dbc );
+    if ( log_info.log_flag )
+    {
+        sprintf( conn-> msg,
+                "\n\t\tExit:[%s]",
+                    __get_return_status( ret, s1 ));
+
+        dm_log_write( __FILE__,
+                __LINE__,
+                LOG_INFO,
+                LOG_INFO,
+                conn-> msg );
+    }
+    if (ret == SQL_ERROR)
+    {
+        if ( CHECK_SQLTRANSACT( conn))
+        {
+            ret = SQLTRANSACT( conn,SQL_NULL_HENV,conn->driver_dbc,SQL_ROLLBACK);
+            if ( !SQL_SUCCEEDED( ret ))
+            {
+                dm_log_write( __FILE__, __LINE__, LOG_INFO,
+                                    LOG_INFO, "Error: Failed to rollback Transaction." );
+            }
+            else
+            {
+                dm_log_write( __FILE__, __LINE__, LOG_INFO,
+                                    LOG_INFO, " Transaction rollback successful." );
+                ret = SQLDISCONNECT( conn, conn -> driver_dbc );
+                if ( log_info.log_flag )
+                {
+                    sprintf( conn-> msg, "\n\t\tExit:[%s]", __get_return_status( ret, s1 ));
+                    dm_log_write( __FILE__, __LINE__, LOG_INFO, LOG_INFO, conn-> msg );
+                }
+            }
+        }
+    }
 
     if ( SQL_SUCCEEDED( ret ))
     {


### PR DESCRIPTION
### Description:

This PR addresses the connection leak detailed in #230 .

In unixODBC v2.3.12, the `pooling_enabled` logic path in `close_pooled_connection()` fails to handle `SQL_ERROR `(SQLSTATE 25000) when a driver refuses a disconnect due to an active transaction.

**Key Changes:**

Checks return status of `SQLDISCONNECT `inside `DriverManager/SQLConnect.c`.

Performs a `SQL_ROLLBACK `if a transaction is blocking the closure.

Retries the disconnect to ensure the physical socket is closed.

This has been verified to resolve orphaned sessions in `PHP 8.3 + Ingres ODBC` environments where connection pooling is enabled.

Fixes #230 