### PR TITLE
Add destructor in __clear_ini_cache added inst_logClose

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@
     * Allow skipping SQLGetData when processing SQL_PARAM_OUTPUT_STREAM
     * Fix resultant interupted_func when SQLMoreResults is called async
     * Handle uncommitted transactions in pooled disconnect
+    * Add inst_logClose to close and clear ODBCINSTLog
+    * Call inst_logClose and __clear_ini_cache on shared library closure
 
 7-Oct-2025
 2.3.14

--- a/include/odbcinstext.h
+++ b/include/odbcinstext.h
@@ -370,6 +370,25 @@ int INSTAPI ODBCINSTValidateProperties( HODBCINSTPROPERTY hFirstProperty, HODBCI
 /* ONLY IMPLEMENTED IN DRIVER SETUP (not in ODBCINST) */
 int INSTAPI ODBCINSTGetProperties( HODBCINSTPROPERTY hFirstProperty );
 
+#if defined(__GNUC__) || defined(__clang__)
+#define PORTABLE_DESTRUCTOR __attribute__((destructor))
+#define REGISTER_DESTRUCTOR(func)
+
+#elif defined(_MSC_VER)
+#include <stdlib.h>
+#define PORTABLE_DESTRUCTOR
+#define REGISTER_DESTRUCTOR(func) \
+    static void register_##func(void) { atexit(func); } \
+    __pragma(section(".CRT$XCU", read)) \
+    __declspec(allocate(".CRT$XCU")) static void (*pRegister_##func)(void) = register_##func;
+
+#else
+#define PORTABLE_DESTRUCTOR
+#define REGISTER_DESTRUCTOR(func)
+#warning "Destructor attribute not supported"
+
+#endif
+
 #if defined(__cplusplus)
          }
 #endif

--- a/odbcinst/SQLGetPrivateProfileString.c
+++ b/odbcinst/SQLGetPrivateProfileString.c
@@ -327,6 +327,7 @@ static void save_ini_cache( int ret,
 	mutex_exit( &mutex_ini );
 }
 
+PORTABLE_DESTRUCTOR
 void __clear_ini_cache( void ) 
 {
 	mutex_entry( &mutex_ini );
@@ -335,6 +336,8 @@ void __clear_ini_cache( void )
 
 	mutex_exit( &mutex_ini );
 }
+
+REGISTER_DESTRUCTOR(__clear_ini_cache)
 
 #else
 

--- a/odbcinst/_logging.c
+++ b/odbcinst/_logging.c
@@ -201,3 +201,16 @@ int inst_logClear( void )
     return ret;
 }
 
+PORTABLE_DESTRUCTOR
+void inst_logClose( void )
+{
+
+    local_mutex_entry();
+
+    if ( hODBCINSTLog )
+        logClose( hODBCINSTLog );
+
+    local_mutex_exit();
+}
+
+REGISTER_DESTRUCTOR(inst_logClose)

--- a/odbcinst/odbcinst.exp
+++ b/odbcinst/odbcinst.exp
@@ -84,4 +84,5 @@ iniPropertyNext
 iniToUpper
 iniValue
 inst_logPushMsg
+inst_logClose
 __clear_ini_cache


### PR DESCRIPTION
This enables the allocations to be cleared on a dlclose of unixODBC.

While using unixODBC I encountered a memory leak of unixODBC internals. unixODBC was dynamicly linked to a MariaDB connector shared library. In some cases its dlclosed.

By adding destructor attributes at these locations I resolved the memory leaks.

I've only tested on Linux. I'm relying on AI on the Windows portability, so I'm relying on CI and review to check this is correct.
edit; which in hindsight, maybe that was stupid overkill given the name/scope of this project :facepalm: .

There's an obvious gap still there, that static libraries will require a caller to explictly call these functions.

ref: https://jira.mariadb.org/browse/MDEV-38838