### PR TITLE
Fix NULL deref in connection pool credential match

### DIFF
--- a/DriverManager/SQLConnect.c
+++ b/DriverManager/SQLConnect.c
@@ -2906,6 +2906,20 @@ static int sql_strcmp( SQLCHAR *s1, SQLCHAR *s2, SQLSMALLINT l1, SQLSMALLINT l2 
         return 1;
     }
 
+    /*
+     * A missing user name or password is passed as a NULL pointer, but
+     * copy_nts() stores it as an empty string on the pooled side. Treat
+     * NULL as "" so the comparison matches instead of dereferencing NULL.
+     */
+    if ( s1 == NULL )
+    {
+        s1 = (SQLCHAR *) "";
+    }
+    if ( s2 == NULL )
+    {
+        s2 = (SQLCHAR *) "";
+    }
+
     if ( l1 == SQL_NTS )
     {
         return strcmp((char*) s1, (char*)s2 );


### PR DESCRIPTION
`sql_strcmp()` in the driver manager dereferences the user name or password when matching a pooled connection. For a DSN with no credentials the application passes a NULL pointer, and `copy_nts()` stores the pooled side as an empty string, so the lengths compare equal and `strcmp(NULL, "")` segfaults inside `SQLConnect`. The server operand was already guarded against this; the user and password operands were not.

Fix: treat a NULL operand as `""`.

Reproduced on Linux against the MDBTools driver with driver-manager pooling enabled:

```ini
# odbcinst.ini
[ODBC]
Pooling=Yes
[MDBTools]
Driver=/path/to/libmdbodbc.so
CPTimeout=60
# odbc.ini
[mdbpool]
Driver=MDBTools
Database=/path/to/test.mdb
```

A connect/disconnect loop against the credential-less DSN, with `SQLSetEnvAttr(SQL_NULL_HANDLE, SQL_ATTR_CONNECTION_POOLING, SQL_CP_ONE_PER_DRIVER, 0)`, SIGSEGVs on the second connect (the pool match) with 2.3.9 and current master, and completes cleanly with this patch.

This is the unixODBC-side root cause behind php/php-src#22512, where pdo_odbc worked around it by passing `""` instead of NULL credentials.
